### PR TITLE
Fix `builder.toml` information

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -6,5 +6,5 @@ description = "ubi 8 base image with no buildpacks included. To use, specify bui
 [stack]
   build-image = "docker.io/paketocommunity/build-ubi-base:0.0.1"
   id = "io.buildpacks.stacks.ubi8"
-  run-image = "index.docker.io/paketocommunity/run-ubi-base:0.0.1"
-  run-image-mirrors = ["gcr.io/paketo-community/run-ubi-base:0.0.1"]
+  run-image = "index.docker.io/paketocommunity/run-ubi-base:latest"
+  run-image-mirrors = []


### PR DESCRIPTION
Makes change to latest run image and removes gcr reference because we do not push there

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
