### PR TITLE
Update of references of ubi base stack pointing to ubi8 base stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,20 @@
 
 ## `paketocommunity/builder:ubi-buildpackless-base`
 
-This builder uses the [ubi Base Stack](https://github.com/paketo-community/ubi-base-stack/) (a Red Hat Ubi 8 base image)
-and contains **no buildpacks nor order groups**. To use this builder, you must specify buildpacks and extensions
-at build time using whatever mechanisms your CNB platform of choice offers.
+This builder uses the [UBI 8 Base Stack](https://github.com/paketo-buildpacks/ubi8-base-stack) (a Red Hat Ubi 8 base image) and contains **no buildpacks nor order groups**.
+To use this builder, you must specify buildpacks and extensions at build time using whatever mechanisms your CNB platform of choice offers.
 
-For example, with the `pack` CLI, use `--buildpack` as follows:
+For example, with the `pack` CLI, use `--buildpack` or/and `--extension` as follows:
+
 ```
 pack build nodejs-with-buildpackless-builder \
            --path ./app-dir \
-           --buildpack paketo-buildpacks/nodejs \
-           --extension docker.io/paketocommunity/ubi-nodejs-extension \
+           --buildpack paketobuildpacks/nodejs \
+           --extension paketobuildpacks/ubi-nodejs-extension \
            --builder paketocommunity/builder-ubi-buildpackless-base
 ```
 
-To see which versions of build and run images and the lifecycle
-are contained within a given builder version, see the
-[Releases](https://github.com/paketo-community/builder-ubi-buildpackless-base/releases) on this
-repo. This information is also available in the `builder.toml`.
+To see which versions of build and run images and the lifecycle are contained within a given builder version, see the [Releases](https://github.com/paketo-community/builder-ubi-buildpackless-base/releases) on this repo. This information is also available in the `builder.toml`.
 
-For more information about this builder and how to use it, visit the [Paketo
-builder documentation](https://paketo.io/docs/builders/).  To learn about the
-stack included in this builder, visit the [Paketo stack
-documentation](https://paketo.io/docs/stacks/).
+For more information about this builder and how to use it, visit the [Paketo builder documentation](https://paketo.io/docs/builders/).
+To learn about the stack included in this builder, visit the [Paketo stack documentation](https://paketo.io/docs/stacks/).

--- a/builder.toml
+++ b/builder.toml
@@ -4,7 +4,7 @@ description = "ubi 8 base image with no buildpacks included. To use, specify bui
   version = "0.20.6"
 
 [stack]
-  build-image = "docker.io/paketocommunity/build-ubi-base:0.0.102"
+  build-image = "docker.io/paketobuildpacks/build-ubi8-base:0.0.103"
   id = "io.buildpacks.stacks.ubi8"
-  run-image = "index.docker.io/paketocommunity/run-ubi-base:latest"
+  run-image = "index.docker.io/paketobuildpacks/run-ubi8-base:latest"
   run-image-mirrors = []


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR changes the references of ubi-base-stack to ubi8-base-stack.

Intentionally I've set the builder pointing to version 0.0.103, to validate that the github-actions will upgrade the stack to version 0.0.104

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
